### PR TITLE
警告メッセージの出力先を変更

### DIFF
--- a/sqrd.py
+++ b/sqrd.py
@@ -972,7 +972,7 @@ if __name__ == '__main__':
 	while len(data_bits) != 0:
 		#モード指示子(mode indicator)の取得
 		if len(data_bits[:4]) != 4:
-			print u'\n残りビット数が4ビット未満のため終了'
+			sys.stderr.write(u'\n残りビット数が4ビット未満のため終了\n')
 			break
 		mode = int(data_bits[:4], 2)
 		m = ''


### PR DESCRIPTION
出力結果だけを得たいときに、警告メッセージが標準出力に出てしまう問題を解消

SECCON 2015 Online qualsのQR(nonogram)でこれをありがたく使わせていただいていたら、ぶっ壊れQRコードが出てきたときに警告メッセージが標準出力に出てしまっていたので :question: ってなって気づいたので修正。
